### PR TITLE
Add redhat-rpm-config to packages.yml

### DIFF
--- a/roles/ansible-keylime/tasks/packages.yml
+++ b/roles/ansible-keylime/tasks/packages.yml
@@ -78,6 +78,11 @@
       name: PyYAML
       state: latest
 
+-name: install redhat-rpm-config
+  dnf:
+      name: redhat-rpm-config
+      state: latest
+
 - name: install tpm2-tss
   dnf:
       name: tpm2-tss


### PR DESCRIPTION
Now that we are installing with setup tools we need to add a gcc
dependency to redhat-rpm-config