### PR TITLE
Don't update all system packages before an install

### DIFF
--- a/roles/ansible-keylime/tasks/main.yml
+++ b/roles/ansible-keylime/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Upgrade all packages
-  dnf:
-    name: "*"
-    state: latest
-
 - name: Install dependencies
   dnf:
     name: "{{ dependencies }}"


### PR DESCRIPTION
We don't want to be in the business of updating unrelated packages that
might be on the users' systems.