### PR TITLE
Add support for the rust agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You now need to start the following services.
 
 To run the agent, navigate to the rust-keylime directory and start the agent. 
 
-`# RUST_LOG=keylime_agent=trace cargo run `
+`# RUST_LOG=keylime_agent=trace cargo run --bin keylime_agent `
 
 | Note: Keylime Agent requires a TPM active that the agent can take ownership on|
 | --- |

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Build Status](https://travis-ci.org/keylime/ansible-keylime.svg?branch=master)](https://travis-ci.org/keylime/ansible-keylime) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/keylime-project/community)
 
-Ansible role to deploy [Keylime](https://github.com/keylime/keylime) against
+Ansible role to deploy [Keylime](https://github.com/keylime/keylime) with the [rust implementation of the keylime agent](https://github.com/keylime/rust-keylime) against
 a Hardware TPM.
 
-The role is currently configured to work with Fedora 32.
+The role is currently configured to work with Fedora 35.
 
 Contributions are welcome, should anyone wish to have this role provision other
 Linux distributions.
@@ -35,13 +35,15 @@ so you will need to install golang and set the following value in
 
 Alternately you can set `openssl` which has no other dependencies.
 
-You now need to start the following three services.
+You now need to start the following services.
 
 `# keylime_verifier`
 
 `# keylime_registrar`
 
-`# keylime_agent`
+To run the agent, navigate to the rust-keylime directory and start the agent. 
+
+`# RUST_LOG=keylime_agent=trace cargo run `
 
 | Note: Keylime Agent requires a TPM active that the agent can take ownership on|
 | --- |

--- a/roles/ansible-keylime/tasks/main.yml
+++ b/roles/ansible-keylime/tasks/main.yml
@@ -3,3 +3,37 @@
   dnf:
     name: "{{ dependencies }}"
     state: latest
+
+- name: Install Rust 
+  shell: "curl https://sh.rustup.rs -sSf | sh -s -- -y"
+  changed_when: false
+
+- name: Set source $HOME
+  shell: "source $HOME/.cargo/env"
+  args:
+    chdir: /root/
+  changed_when: false  
+
+- name: Clone Rust-Keylime
+  git:
+    repo: https://github.com/keylime/rust-keylime
+    dest: /root/rust-keylime
+
+- name: Run Rust-Keylime Makefile
+  shell: "make && make install"
+  args:
+    chdir: /root/rust-keylime
+  changed_when: false
+
+- name: Run Cargo build
+  shell: "cargo build"
+  args:
+    chdir: /root/rust-keylime
+  changed_when: false
+
+- name: Set TPM2TOOLS_TCTI environment variable
+  lineinfile:
+    dest: /etc/environment
+    state: present
+    regexp: '^TPM2TOOLS_TCTI'
+    line: 'TPM2TOOLS_TCTI="device:/dev/tpmrm0"'

--- a/roles/ansible-keylime/vars/main.yml
+++ b/roles/ansible-keylime/vars/main.yml
@@ -1,11 +1,9 @@
 ---
 # requirements
 dependencies:
-  ['PyYAML',
-   'autoconf',
+  ['autoconf',
    'autoconf-archive',
    'automake',
-   'compat-openssl10-devel',
    'dbus-devel',
    'gcc',
    'git',
@@ -26,8 +24,13 @@ dependencies:
    'redhat-rpm-config',
    'tpm2-tools',
    'tpm2-tss',
+   'tpm2-tss-devel',
    'uriparser-devel',
-   'efivar-devel']
+   'efivar-devel',
+   'cargo',
+   'openssl-devel',
+   'zeromq-devel',
+   'libarchive-devel']
 
 # section for vars
 shell_profiles:

--- a/roles/ansible-keylime/vars/main.yml
+++ b/roles/ansible-keylime/vars/main.yml
@@ -17,6 +17,7 @@ dependencies:
    'pkg-config',
    'python3-cryptography',
    'python3-devel',
+   'python3-pyyaml',
    'python3-yaml',
    'python3-simplejson',
    'python3-sqlalchemy',


### PR DESCRIPTION
Add support for the rust agent and update packages for use with Fedora 35.
In `roles/ansible-keylime/tasks/main.yml`, tasks are added to clone and install the rust agent.
Updates packages for new Fedora versions, and adds dependencies for the new agent. @mpeters 