### PR TITLE
Fix: add clang to dependencies

### DIFF
--- a/roles/ansible-keylime/vars/main.yml
+++ b/roles/ansible-keylime/vars/main.yml
@@ -31,7 +31,8 @@ dependencies:
    'cargo',
    'openssl-devel',
    'zeromq-devel',
-   'libarchive-devel']
+   'libarchive-devel',
+   'clang']
 
 # section for vars
 shell_profiles:


### PR DESCRIPTION
The pacakge clang is required for rust-keylime building.